### PR TITLE
Fix `Error: Failed to add page binding with name ___pepr_cs: window['___pepr_cs'] already exists!

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -170,7 +170,11 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
 
     if (this.contentScriptDebug.enabled) {
       if ('exposeFunction' in page) {
-        await page.exposeFunction(this.debugBindingName, onDebugBindingCalled)
+        try {
+          await page.exposeFunction(this.debugBindingName, onDebugBindingCalled);
+        } catch (err) {
+          this.debug('`debugBindingName` function is already exposed');
+        }
       }
     }
     // Even without a recaptcha script tag we're trying, just in case.


### PR DESCRIPTION
When page.solveRecaptchas() is called multiple times, an error is thrown

```
Error: Failed to add page binding with name ___pepr_cs: window['___pepr_cs'] already exists!
```

In my test I use puppeteer@14.4.1 with its default Chrome, puppeteer-extra@3.3.4 and puppeteer-extra-plugin-recaptcha@3.6.8. I haven't tried other versions.